### PR TITLE
Updated NSG creation on Subnets

### DIFF
--- a/examples/Commerical/basic_dmz_spoke/main.tf
+++ b/examples/Commerical/basic_dmz_spoke/main.tf
@@ -12,7 +12,7 @@ module "mod_vnet_spoke" {
   deploy_environment          = var.deploy_environment
   org_name                    = var.org_name
   environment                 = var.environment
-  workload_name               = var.id_name
+  workload_name               = var.dmz_name
 
   # Collect Spoke Virtual Network Parameters
   # Spoke network details to create peering and other setup
@@ -31,19 +31,19 @@ module "mod_vnet_spoke" {
   log_analytics_logs_retention_in_days = 30
 
   # Provide valid VNet Address space for spoke virtual network.    
-  virtual_network_address_space = var.id_vnet_address_space # (Required)  Spoke Virtual Network Parameters
+  virtual_network_address_space = var.dmz_vnet_address_space # (Required)  Spoke Virtual Network Parameters
 
   # (Required) Multiple Subnets, Service delegation, Service Endpoints, Network security groups
   # These are default subnets with required configuration, check README.md for more details
   # Route_table and NSG association to be added automatically for all subnets listed here.
   # subnet name will be set as per Azure naming convention by defaut. expected value here is: <App or project name>
-  spoke_subnets = var.id_subnets
+  spoke_subnets = var.dmz_subnets
 
   # Private DNS Zone Settings
   # If you do want to create addtional Private DNS Zones, 
   # add in the list of private_dns_zones to be created.
   # else, remove the private_dns_zones argument.
-  private_dns_zones = var.id_private_dns_zones
+  private_dns_zones = var.dmz_private_dns_zones
 
   # By default, this will apply resource locks to all resources created by this module.
   # To disable resource locks, set the argument to `enable_resource_locks = false`.

--- a/examples/Commerical/basic_dmz_spoke/parameters.tfvars
+++ b/examples/Commerical/basic_dmz_spoke/parameters.tfvars
@@ -24,13 +24,14 @@ enable_traffic_analytics = true
 # DMZ Virtual Network Parameters
 dmz_name               = "vpn"
 dmz_vnet_address_space = ["10.8.39.0/24"]
-dmz_subnets = {
-  default = {
-    name                                       = "vpn"
-    address_prefixes                           = ["10.8.39.224/27"]
+ dmz_subnets = {
+  untrusted = {
+    name                                       = "untrusted"
+    address_prefixes                           = ["10.8.39.0/27"]
     service_endpoints                          = ["Microsoft.Storage"]
     private_endpoint_network_policies_enabled  = false
     private_endpoint_service_endpoints_enabled = true
+    
     nsg_subnet_rules = [
       {
         name                       = "Allow-Traffic-From-Spokes",
@@ -46,8 +47,23 @@ dmz_subnets = {
       }
     ]
   }
+  trusted = {
+    name                                       = "trusted"
+    address_prefixes                           = ["10.8.39.64/27"]
+    service_endpoints                          = ["Microsoft.Storage"]
+    private_endpoint_network_policies_enabled  = false
+    private_endpoint_service_endpoints_enabled = true
+  }
+  semitrusted = {
+    name                                       = "semitrusted"
+    address_prefixes                           = ["10.8.39.128/27"]
+    service_endpoints                          = ["Microsoft.Storage"]
+    private_endpoint_network_policies_enabled  = false
+    private_endpoint_service_endpoints_enabled = true
+    nsg_subnet_rules = []
+  }
 }
-
+ 
 # Private DNS Zones
 # Add in the list of private_dns_zones to be created.
 dmz_private_dns_zones = []

--- a/examples/Commerical/basic_dmz_spoke/variables.tf
+++ b/examples/Commerical/basic_dmz_spoke/variables.tf
@@ -62,24 +62,24 @@ variable "lock_level" {
 # Identity    ###
 #################
 
-variable "id_name" {
+variable "dmz_name" {
   description = "A name for the id. It defaults to id-core."
   type        = string
-  default     = "id-core"
+  default     = "dmz"
 }
 
-variable "id_vnet_address_space" {
+variable "dmz_vnet_address_space" {
   description = "The address space of the operations virtual network."
   type        = list(string)
   default     = ["10.8.9.0/26"]
 }
 
-variable "id_subnets" {
+variable "dmz_subnets" {
   description = "The subnets of the operations virtual network."
   default     = {}
 }
 
-variable "id_private_dns_zones" {
+variable "dmz_private_dns_zones" {
   description = "The private DNS zones of the operations virtual network."
   type        = list(string)
   default     = []

--- a/outputs.tf
+++ b/outputs.tf
@@ -57,13 +57,14 @@ output "subnet_address_prefixes" {
   value       = flatten(concat([for s in azurerm_subnet.default_snet : s.address_prefixes]))
 }
 
+//TODO: Fix this output
 # Network Security group ids
-output "network_security_group_ids" {
+/* output "network_security_group_ids" {
   description = "Map of ids for default NSGs"
   value = { for key, id in zipmap(
     sort(keys(var.spoke_subnets)),
     sort(values(azurerm_network_security_group.nsg)[*]["id"])) :
-  key => { key = key, id = id } }
+  key => { key = key, id = id }  }
 }
 
 output "network_security_group_names" {
@@ -73,7 +74,8 @@ output "network_security_group_names" {
     sort(values(azurerm_network_security_group.nsg)[*]["name"])) :
   key => { key = key, name = name } }
 }
-
+ */
+ 
 # DDoS Protection Plan
 output "ddos_protection_plan_id" {
   description = "Ddos protection plan details"

--- a/resources.workload.spoke.network.watcher.tf
+++ b/resources.workload.spoke.network.watcher.tf
@@ -21,7 +21,13 @@ data "azurerm_network_watcher" "nwatcher" {
 # Network flow logs for subnet and NSG
 #-----------------------------------------
 resource "azurerm_network_watcher_flow_log" "nwflog" {
-  for_each                  = var.spoke_subnets
+  //This basically check to see if the user has defined the nsg_subnet_rules block for each
+  //  subnet variable and if one is found then make a flow log for that NSG
+  for_each = {
+    for subnet, values in var.spoke_subnets : 
+        subnet => values if values.nsg_subnet_rules != null
+  }
+
   name                      = lower("Network-Watcher-flog-log-${each.value.name}")
   network_watcher_name      = data.azurerm_network_watcher.nwatcher.name
   resource_group_name       = "NetworkWatcherRG" # Must provide Netwatcher resource Group

--- a/resources.workload.spoke.nsg.tf
+++ b/resources.workload.spoke.nsg.tf
@@ -2,15 +2,20 @@
 # Licensed under the MIT License.
 
 resource "azurerm_network_security_group" "nsg" {
-  for_each            = var.spoke_subnets
+  //This basically check to see if the user has defined the nsg_subnet_rules block for each
+  //  subnet variable and if one is found then make an NSG for that subnet.
+  for_each = {
+    for subnet, values in var.spoke_subnets : 
+        subnet => values if values.nsg_subnet_rules != null
+  }
 
   name                = var.custom_spoke_network_security_group_name != null ? "${var.custom_spoke_network_security_group_name}_${each.key}" : "${data.azurenoopsutils_resource_name.nsg[each.key].result}"
   resource_group_name = local.resource_group_name
   location            = local.location
 
-  tags                = merge({ "ResourceName" = lower("nsg_${each.key}") }, local.default_tags, var.add_tags, )
-  
-dynamic "security_rule" {
+  tags = merge({ "ResourceName" = lower("nsg_${each.key}") }, local.default_tags, var.add_tags, )
+
+  dynamic "security_rule" {
     for_each = each.value.nsg_subnet_rules != null ? each.value.nsg_subnet_rules : []
 
     content {
@@ -39,7 +44,13 @@ dynamic "security_rule" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "nsgassoc" {
-  for_each                  = var.spoke_subnets
+  //This basically check to see if the user has defined the nsg_subnet_rules block for each
+  //  subnet variable and if one is found then make an NSG association between the NSG and subnet.
+  for_each = {
+    for subnet, values in var.spoke_subnets : 
+        subnet => values if values.nsg_subnet_rules != null
+  }
+
   subnet_id                 = azurerm_subnet.default_snet[each.key].id
   network_security_group_id = azurerm_network_security_group.nsg[each.key].id
 }

--- a/variables.subnet.tf
+++ b/variables.subnet.tf
@@ -14,7 +14,7 @@ variable "spoke_subnets" {
     service_endpoints                          = list(string)
     private_endpoint_network_policies_enabled  = bool
     private_endpoint_service_endpoints_enabled = bool
-
+    
     # Delegation block - see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet#delegation
     delegation = optional(object({
       name = string


### PR DESCRIPTION
## Describe your changes
Changed Subnet code so that the user can either:
1. create a subnet with an NSG that has default and custom rules
2. create a subnet with an NSG that only has default rules
3. create a subnet without an NSG

The way this is done is: 
1. Add an `nsg_subnet_rules` block to the subnet definition. (No change to module )
  ```
dmz_subnets = {
  untrusted = {
    name                                       = "untrusted"
    address_prefixes                           = ["10.8.39.0/27"]
   
    nsg_subnet_rules = [
      {
        name                       = "Allow-Traffic-From-Spokes",
        description                = "Allow traffic from spokes",
        priority                   = 100,
        direction                  = "Inbound",
        access                     = "Allow",
        protocol                   = "Tcp",
        source_port_range          = "*",
        destination_port_range     = "443",
        source_address_prefix      = "*",
        destination_address_prefix = "*"
      }
    ]
}
```
2. Add an empty `nsg_subnet_rules` block to the subnet definition
```
 dmz_subnets = {
  semitrusted = {
    name                                       = "semitrusted"
    address_prefixes                           = ["10.8.39.128/27"]
    service_endpoints                          = ["Microsoft.Storage"]

    nsg_subnet_rules = []
  }
}
```
3. Do not add an `nsg_subnet_rules` block to the subnet definition
```
 dmz_subnets = {
  trusted = {
    name                                       = "trusted"
    address_prefixes                           = ["10.8.39.64/27"]
    service_endpoints                          = ["Microsoft.Storage"]
    private_endpoint_network_policies_enabled  = false
    private_endpoint_service_endpoints_enabled = true
  }
}
```

## Issue number
Closes #6 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

