### PR TITLE
Bug fix: Making dependency on subnet completion

### DIFF
--- a/resources.workload.spoke.peering.tf
+++ b/resources.workload.spoke.peering.tf
@@ -6,7 +6,7 @@
 # Peering between Hub and Spoke Virtual Network
 #-----------------------------------------------
 resource "azurerm_virtual_network_peering" "spoke_to_hub" {
-  depends_on                   = [azurerm_virtual_network.spoke_vnet, data.azurerm_virtual_network.hub_vnet]
+  depends_on                   = [azurerm_subnet.default_snet, data.azurerm_virtual_network.hub_vnet]
   name                         = lower("peering-to-hub-${data.azurerm_virtual_network.hub_vnet.name}")
   resource_group_name          = local.resource_group_name
   virtual_network_name         = azurerm_virtual_network.spoke_vnet.name
@@ -18,7 +18,7 @@ resource "azurerm_virtual_network_peering" "spoke_to_hub" {
 }
 
 resource "azurerm_virtual_network_peering" "hub_to_spoke" {
-  depends_on                   = [azurerm_virtual_network.spoke_vnet, data.azurerm_virtual_network.hub_vnet]
+  depends_on                   = [azurerm_subnet.default_snet, data.azurerm_virtual_network.hub_vnet]
   provider                     = azurerm.hub_network
   name                         = lower("peering-${data.azurerm_virtual_network.hub_vnet.name}-to-${var.workload_name}-spoke")
   resource_group_name          = data.azurerm_virtual_network.hub_vnet.resource_group_name


### PR DESCRIPTION
## Describe your changes
Changed the peering resources to wait for the subnets to complete rather than waiting for the vnet to complete.  This fixes an error where the peering tries to be created and is failing because the subnet is still being created on the vnet so a peering can't be applied yet.

## Issue number

#12

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

